### PR TITLE
Hide GroupButton in volume detail page

### DIFF
--- a/pkg/harvester/config/harvester-cluster.js
+++ b/pkg/harvester/config/harvester-cluster.js
@@ -195,7 +195,8 @@ export function init($plugin, store) {
     },
     resource: PVC,
     resourceDetail: HCI.VOLUME,
-    resourceEdit: HCI.VOLUME
+    resourceEdit: HCI.VOLUME,
+    canYaml: false,
   });
   virtualType({
     labelKey: 'harvester.volume.label',


### PR DESCRIPTION
H. extension
<img width="1496" alt="Screenshot 2024-10-02 at 11 45 20 AM" src="https://github.com/user-attachments/assets/294ed1e6-df7d-4ea2-8eee-280b53a2ab2b">

H. v1.4 
<img width="1488" alt="Screenshot 2024-10-02 at 11 45 32 AM" src="https://github.com/user-attachments/assets/4217354c-4db5-4623-b155-db713e3166db">


Due to [canViewYaml](https://github.com/rancher/dashboard/blob/5587fa712c7cf51e75c42311fe778a230cefdd4c/shell/components/ResourceDetail/Masthead.vue#L89) prop is added in Mashead.vue recently. 
