### PR TITLE
fix missing virtualSize column

### DIFF
--- a/pkg/harvester/config/harvester-cluster.js
+++ b/pkg/harvester/config/harvester-cluster.js
@@ -31,6 +31,7 @@ import {
   FINGERPRINT,
   IMAGE_PROGRESS,
   SNAPSHOT_TARGET_VOLUME,
+  IMAGE_VIRTUAL_SIZE
 } from './table-headers';
 
 const TEMPLATE = HCI.VM_VERSION;
@@ -219,8 +220,12 @@ export function init($plugin, store) {
     NAMESPACE_COL,
     IMAGE_PROGRESS,
     IMAGE_DOWNLOAD_SIZE,
+    IMAGE_VIRTUAL_SIZE,
     AGE
   ]);
+  configureType(HCI.IMAGE, {
+    canYaml: false,
+  });
   virtualType({
     labelKey: 'harvester.image.label',
     group: 'root',


### PR DESCRIPTION
Fix bugs in image list / edit page page
- miss virtual size column
- canYaml should be false

<img width="1489" alt="Screenshot 2024-10-03 at 5 32 19 PM" src="https://github.com/user-attachments/assets/6d05f1e4-6e49-4f29-99c0-dad5928f822d">

<img width="1493" alt="Screenshot 2024-10-03 at 5 32 09 PM" src="https://github.com/user-attachments/assets/a6e2f97b-c8be-4b5d-8817-5a3061ca71a9">
