### PR TITLE
fix v-model:value.number for UnitInput and LabelIedinput

### DIFF
--- a/pkg/harvester/components/settings/overcommit-config.vue
+++ b/pkg/harvester/components/settings/overcommit-config.vue
@@ -52,40 +52,36 @@ export default {
 <template>
   <div class="row">
     <div class="col span-12">
-      <template>
-        <UnitInput
-          v-model:value.number="parseDefaultValue.cpu"
-          label-key="harvester.generic.cpu"
-          suffix="%"
-          :delay="0"
-          required
-          :mode="mode"
-          class="mb-20"
-          @update:value="update"
-        />
-
-        <UnitInput
-          v-model:value.number="parseDefaultValue.memory"
-          label-key="harvester.generic.memory"
-          suffix="%"
-          :delay="0"
-          required
-          :mode="mode"
-          class="mb-20"
-          @update:value="update"
-        />
-
-        <UnitInput
-          v-model:value.number="parseDefaultValue.storage"
-          label-key="harvester.generic.storage"
-          suffix="%"
-          :delay="0"
-          required
-          :mode="mode"
-          class="mb-20"
-          @update:value="update"
-        />
-      </template>
+      <UnitInput
+        v-model:value="parseDefaultValue.cpu"
+        label-key="harvester.generic.cpu"
+        suffix="%"
+        :delay="0"
+        required
+        :mode="mode"
+        class="mb-20"
+        @update:value="update"
+      />
+      <UnitInput
+        v-model:value="parseDefaultValue.memory"
+        label-key="harvester.generic.memory"
+        suffix="%"
+        :delay="0"
+        required
+        :mode="mode"
+        class="mb-20"
+        @update:value="update"
+      />
+      <UnitInput
+        v-model:value="parseDefaultValue.storage"
+        label-key="harvester.generic.storage"
+        suffix="%"
+        :delay="0"
+        required
+        :mode="mode"
+        class="mb-20"
+        @update:value="update"
+      />
     </div>
   </div>
 </template>

--- a/pkg/harvester/components/settings/support-bundle-image.vue
+++ b/pkg/harvester/components/settings/support-bundle-image.vue
@@ -29,7 +29,6 @@ export default {
 
   data() {
     let parseDefaultValue = {};
-
     try {
       parseDefaultValue = JSON.parse(this.value.value);
     } catch (error) {
@@ -64,7 +63,6 @@ export default {
   methods: {
     update() {
       const value = JSON.stringify(this.parseDefaultValue);
-
       this.value['value'] = value;
     },
 
@@ -103,32 +101,30 @@ export default {
 <template>
   <div class="row" @input="update">
     <div class="col span-12">
-      <template>
-        <LabeledInput
-          v-model:value="parseDefaultValue.repository"
-          class="mb-20"
-          :mode="mode"
-          required
-          label-key="harvester.setting.supportBundleImage.repo"
-        />
+      <LabeledInput
+        v-model:value="parseDefaultValue.repository"
+        class="mb-20"
+        :mode="mode"
+        required
+        label-key="harvester.setting.supportBundleImage.repo"
+      />
 
-        <LabeledInput
-          v-model:value="parseDefaultValue.tag"
-          class="mb-20"
-          :mode="mode"
-          required
-          label-key="harvester.setting.supportBundleImage.tag"
-        />
+      <LabeledInput
+        v-model:value="parseDefaultValue.tag"
+        class="mb-20"
+        :mode="mode"
+        required
+        label-key="harvester.setting.supportBundleImage.tag"
+      />
 
-        <LabeledSelect
-          v-model:value="parseDefaultValue.imagePullPolicy"
-          class="mb-20"
-          required
-          label-key="harvester.setting.supportBundleImage.imagePullPolicy"
-          :options="imagePolicyOptions"
-          @input="update"
-        />
-      </template>
+      <LabeledSelect
+        v-model:value="parseDefaultValue.imagePullPolicy"
+        class="mb-20"
+        required
+        label-key="harvester.setting.supportBundleImage.imagePullPolicy"
+        :options="imagePolicyOptions"
+        @update:value="update"
+      />
     </div>
   </div>
 </template>

--- a/pkg/harvester/dialog/HarvesterQuotaDialog.vue
+++ b/pkg/harvester/dialog/HarvesterQuotaDialog.vue
@@ -86,7 +86,7 @@ export default {
         {{ t('harvester.modal.quota.bannerMessage') }}
       </Banner>
       <UnitInput
-        v-model:value.number="totalSnapshotSize"
+        v-model:value="totalSnapshotSize"
         :label="t('harvester.snapshot.totalSnapshotSize')"
         :disabled="false"
         :input-exponent="3"

--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -207,7 +207,7 @@ export default {
 
         <LabeledInput
           v-if="!isUntaggedNetwork"
-          v-model.number="config.vlan"
+          v-model:value.number="config.vlan"
           class="mb-20"
           required
           type="number"

--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -329,7 +329,7 @@ export default {
         />
 
         <UnitInput
-          v-model:value.number="storage"
+          v-model:value="storage"
           :label="t('harvester.volume.size')"
           :input-exponent="3"
           :output-modifier="true"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
@@ -80,7 +80,7 @@ export default {
     <div class="col span-6 mb-10">
       <InputOrDisplay name="CPU" :value="cupDisplay" :mode="mode">
         <UnitInput
-          v-model:value.number="localCpu"
+          v-model:value="localCpu"
           label="CPU"
           suffix="C"
           :delay="0"
@@ -96,7 +96,7 @@ export default {
     <div class="col span-6 mb-10">
       <InputOrDisplay :name="t('harvester.virtualMachine.input.memory')" :value="memoryDisplay" :mode="mode">
         <UnitInput
-          v-model:value.number="localMemory"
+          v-model:value="localMemory"
           :label="t('harvester.virtualMachine.input.memory')"
           :mode="mode"
           :input-exponent="3"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineReserved.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineReserved.vue
@@ -41,7 +41,7 @@ export default {
 
 <template>
   <UnitInput
-    v-model:value.number="memory"
+    v-model:value="memory"
     :label="t('harvester.virtualMachine.input.reservedMemory')"
     :mode="mode"
     :input-exponent="2"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -272,7 +272,7 @@ export default {
           :mode="mode"
         >
           <UnitInput
-            v-model:value.number="value.size"
+            v-model:value="value.size"
             :output-modifier="true"
             :increment="1024"
             :input-exponent="3"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -215,7 +215,7 @@ export default {
           :mode="mode"
         >
           <UnitInput
-            v-model:value.number="value.size"
+            v-model:value="value.size"
             :output-modifier="true"
             :increment="1024"
             :input-exponent="3"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -514,7 +514,7 @@ export default {
       <template #type>
         <LabeledInput
           v-if="!isSingle"
-          v-model.number="count"
+          v-model:value.number="count"
           :min="2"
           type="number"
           :label="t('harvester.virtualMachine.instance.multiple.count')"


### PR DESCRIPTION
Some <UnitInput>still require string type `v-model:value`.

- Fix missing <UnitInput in overcommit config setting page
<img width="1492" alt="Screenshot 2024-10-22 at 11 28 01 AM" src="https://github.com/user-attachments/assets/c1a830df-1310-4e15-b22a-d7518a55b0e3">

- Fix several <LabelIednput requires `v-model:value.number`.
<img width="1493" alt="Screenshot 2024-10-22 at 11 44 51 AM" src="https://github.com/user-attachments/assets/b6fe7c51-9096-43a6-bf21-c08f4608acfa">

- Fix support bundle image setting page

![save](https://github.com/user-attachments/assets/bc46a55e-257a-4c81-9966-b25e7908e7c8)

