### PR TITLE
Fix unexpected Nics dropdown when creating network configuration

### DIFF
--- a/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
+++ b/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
@@ -457,7 +457,7 @@ export default {
               :options="nicOptions"
               :array-list-props="{
                 addLabel: t('harvester.vlanConfig.uplink.nics.addLabel'),
-                initialEmptyRow: true,
+                initialEmptyRow: false,
                 title: t('harvester.vlanConfig.uplink.nics.label'),
                 required: true,
                 protip: false,


### PR DESCRIPTION
Due to `:defaultAddValue` was added in this [commit](https://github.com/rancher/dashboard/commit/00b773a16daef20734be52879b502ba42ed72ee0), the default selected item will be `option[0].value` even `option[0].disabled = true` (Doesn't make sense to me)


Miminal change is set `initialEmptyRow: true` to let user add nic dropdown manully.

Current behavior
<img width="1482" alt="Screenshot 2024-10-22 at 1 38 58 PM" src="https://github.com/user-attachments/assets/ad13562c-bfcb-4682-9a82-987216ecf56b">


After fix
https://github.com/user-attachments/assets/a01c9f38-22f4-45a9-bcbc-f54ece3acbf9

