### PR TITLE
Fix unexpected default nics dropdown item when creating network configuration

### DIFF
--- a/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
+++ b/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
@@ -361,21 +361,6 @@ export default {
 
       this.nicErrors = uniq(nicErrors);
     },
-
-    'value.spec.uplink.nics'(nics = []) {
-      const nicErrors = [];
-      const options = this.nicOptions || [];
-
-      nics.map((n) => {
-        const option = options.find(option => option.value === n);
-
-        if ((option && option?.disabled) || !option) {
-          nicErrors.push(this.t('harvester.vlanConfig.uplink.nics.validate.available', { nic: n }, true));
-        }
-      });
-
-      this.nicErrors = uniq(nicErrors);
-    }
   },
 };
 </script>
@@ -455,6 +440,7 @@ export default {
               v-model:value="value.spec.uplink.nics"
               :mode="mode"
               :options="nicOptions"
+              :enableDefaultAddValue="false"
               :array-list-props="{
                 addLabel: t('harvester.vlanConfig.uplink.nics.addLabel'),
                 initialEmptyRow: true,


### PR DESCRIPTION
Due to `:defaultAddValue` was added in this [commit](https://github.com/rancher/dashboard/commit/00b773a16daef20734be52879b502ba42ed72ee0), the default selected item will be `option[0].value` even `option[0].disabled = true` which doesn't make sense to me.

With https://github.com/torchiaf/dashboard/pull/7 change, we can have same behavior in harvester/dashboard 

**Current behavior**
<img width="1482" alt="Screenshot 2024-10-22 at 1 38 58 PM" src="https://github.com/user-attachments/assets/ad13562c-bfcb-4682-9a82-987216ecf56b">


**After fix**

https://github.com/user-attachments/assets/0f952021-cf91-4b5c-8485-54c2efe3a595


