### PR TITLE
Set 1.4.0 in pkg/harvester/package.json

### DIFF
--- a/pkg/harvester/package.json
+++ b/pkg/harvester/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvester",
   "description": "Provides the Virtualization Management feature in Rancher Manager",
-  "version": "0.1.0",
+  "version": "1.4.0",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
Current doc links are read harvester doc version from `pkg/harvester/package.json`.  See https://github.com/harvester/dashboard/blob/master/pkg/harvester/config/doc-links.js

Set 1.4.0 in pkg/harvester/package.json

Fix 
<img width="1496" alt="Screenshot 2024-10-22 at 4 31 36 PM" src="https://github.com/user-attachments/assets/aceb2398-ea61-4940-b6ba-9c4bb15bc8cb">
